### PR TITLE
add ability for script to work even when the GPG file is read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ I use this to keep track of my web passwords.
 
 Usage : 
 
-    $ ./encryptvi 
+    $ ./viencrypt
     No filename specified. Using default passwords.gpg
     passwords.gpg doesn't exist. Starting from empty file.
     Password: 
@@ -14,12 +14,12 @@ Usage :
 
 or for any other file
 
-    $ ./encryptvi my.love.notes
+    $ ./viencrypt my.love.notes
     Password:
     <editor pops up and you edit your file. Once you exit it saves it encrypted>
     
 To change your editor (in bash) :
 
     $ export EDITOR=pico
-    $ ./encryptvi
+    $ ./viencrypt
     <now pico pops up>

--- a/viencrypt
+++ b/viencrypt
@@ -40,6 +40,10 @@ tmp=`mktemp` || exit 1
 if [ ! -f $filename ]
 then 
     echo "$filename doesn't exist. Starting from empty file."
+elif [ ! -r $filename ]
+then
+    echo "$filename isn't readable."
+    exit 1
 fi
 
 # prompt for password; don't show typing

--- a/viencrypt
+++ b/viencrypt
@@ -40,10 +40,6 @@ tmp=`mktemp` || exit 1
 if [ ! -f $filename ]
 then 
     echo "$filename doesn't exist. Starting from empty file."
-elif [ ! -w $filename ]
-then
-    echo "$filename isn't writable."
-    exit 1
 fi
 
 # prompt for password; don't show typing
@@ -52,7 +48,7 @@ read -p "Password: " passw; echo
 stty echo
 
 # decrypt into the tmp file
-if [ -f $filename -a -w $filename ]
+if [ -f $filename ]
 then
     echo "$passw" | gpg -q -d --batch --passphrase-fd 0 $filename > $tmp
     if [ $? != 0 ]; then
@@ -60,15 +56,24 @@ then
         $rm $tmp
         exit $?;
     fi
+    # if original is unwritable, hint to the editor that the file shouldn't/can't be updated
+    if [ ! -w $filename ]
+    then
+        chmod -w $tmp
+        echo "$filename isn't writable, so any modifications will be discarded"
+    fi
 fi
 
 # edit the file
 $editor $tmp
 
 # write changes back out
-echo "$passw" | gpg -q -c --batch --passphrase-fd 0 --output $filename --yes --force-mdc $tmp
-$rm $tmp
-if [ $? != 0 ]; then
-    # if gpg didn't work, exit
-    exit $?;
+if [ -w $filename -o ! -f $filename ]
+then
+    echo "$passw" | gpg -q -c --batch --passphrase-fd 0 --output $filename --yes --force-mdc $tmp
+    $rm $tmp
+    if [ $? != 0 ]; then
+        # if gpg didn't work, exit
+        exit $?;
+    fi
 fi

--- a/viencrypt
+++ b/viencrypt
@@ -46,7 +46,7 @@ then
     exit 1
 fi
 
-# don't show typing
+# prompt for password; don't show typing
 stty -echo
 read -p "Password: " passw; echo
 stty echo
@@ -62,7 +62,10 @@ then
     fi
 fi
 
+# edit the file
 $editor $tmp
+
+# write changes back out
 echo "$passw" | gpg -q -c --batch --passphrase-fd 0 --output $filename --yes --force-mdc $tmp
 $rm $tmp
 if [ $? != 0 ]; then


### PR DESCRIPTION
I want to encourage users on my system to use 'viencrypt'.  While it's certainly not too difficult
to have them use GPG by itself to look at read-only files, not all of my users are
super sophisticated, so I want viencrypt to _just work_.

I spent ~15 minutes testing these changes.

Also included in this pull request are: 2) an additional error-check in case the GPG file is `chmod -r`, 3) two documentation-only changes
