### PR TITLE
fix check for shred executable

### DIFF
--- a/viencrypt
+++ b/viencrypt
@@ -28,7 +28,7 @@ else
     filename=$1
 fi
 
-if [ -f `which shred` ]
+if [ `which shred` ]
 then
     rm='shred -u'
 else

--- a/viencrypt
+++ b/viencrypt
@@ -17,7 +17,7 @@ then
     editor="$editor -n -i NONE"
 fi
 
-if [ $# -eq 0 ] 
+if [ $# -eq 0 ]
 then
     echo "No filename specified. Using default $filename"
 elif [ $# -gt 1 ]
@@ -38,7 +38,7 @@ fi
 tmp=`mktemp -t tmp.XXXXXXXXXX` || exit 1
 
 if [ ! -f $filename ]
-then 
+then
     echo "$filename doesn't exist. Starting from empty file."
 elif [ ! -r $filename ]
 then


### PR DESCRIPTION
Fixes the check for a `shred` executable by checking the return value of `which` rather than using a `-f` test.

I've tested this on Ubuntu 12.04 and OS X (where `sh` is really `bash`).

Also included is an automatic trailing whitespace fix which I'm happy to remove if you feel it doesn't belong.

Closes #5
